### PR TITLE
Fix input length in rickrolldle

### DIFF
--- a/src/routes/Games/rickrolldle/+page.svelte
+++ b/src/routes/Games/rickrolldle/+page.svelte
@@ -29,7 +29,7 @@
 
 	let maxedOut = false;
 	const minLength = 2;
-	const maxLength = 10;
+	const maxLength = data.answerLength;
 	/** Whether the current guess can be submitted */
 	$: submittable = currentGuess.length >= minLength && currentGuess.length <= maxLength;
 	$: maxedOut = currentGuess.length >= maxLength;

--- a/src/routes/Games/rickrolldle/game.js
+++ b/src/routes/Games/rickrolldle/game.js
@@ -38,23 +38,25 @@ export class Game {
 
 		this.guesses[this.answers.length] = word;
 
-		const maxLength = 10;
-
 		const available = Array.from(this.answer);
-		const answer = Array(maxLength).fill('_');
+		const answer = Array(this.answerLength).fill('_');
 
 		// first, find exact matches
-		for (let i = 0; i < maxLength; i += 1) {
+		for (let i = 0; i < this.answerLength; i += 1) {
 			if (letters[i] === available[i]) {
 				answer[i] = 'x';
 				available[i] = ' ';
+			}
+			// P1ff5
+			if (letters.length !== this.answerLength) {
+				return false;
 			}
 		}
 
 		// then find close matches (this has to happen
 		// in a second step, otherwise an early close
 		// match can prevent a later exact match)
-		for (let i = 0; i < maxLength; i += 1) {
+		for (let i = 0; i < this.answerLength; i += 1) {
 			if (answer[i] === '_') {
 				const index = available.indexOf(letters[i]);
 				if (index !== -1) {


### PR DESCRIPTION
Update the length of the input in rickrolldle to match the length of the correct answer.

* Set `maxLength` to `data.answerLength` in `src/routes/Games/rickrolldle/+page.svelte`.
* Update the `submittable` variable to use `data.answerLength` in `src/routes/Games/rickrolldle/+page.svelte`.
* Remove the `maxLength` variable in `src/routes/Games/rickrolldle/game.js`.
* Replace `maxLength` with `this.answerLength` in the `enter` method in `src/routes/Games/rickrolldle/game.js`.
* Validate the input length against `this.answerLength` in the `enter` method in `src/routes/Games/rickrolldle/game.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NotPiny/GamesSite/pull/1?shareId=94d0e18b-e7a2-42f5-8b0c-8b61b90c02d4).