### PR TITLE
Fix Rickrolldle to show correct number of squares

### DIFF
--- a/src/routes/Games/rickrolldle/+page.svelte
+++ b/src/routes/Games/rickrolldle/+page.svelte
@@ -127,7 +127,7 @@
 			{@const current = row === i}
 			<h2 class="visually-hidden">Row {row + 1}</h2>
 			<div class="row" class:current>
-				{#each Array.from(Array(10).keys()) as column (column)}
+				{#each Array.from(Array(data.answerLength).keys()) as column (column)}
 					{@const guess = current ? currentGuess : data.guesses[row]}
 					{@const answer = data.answers[row]?.[column]}
 					{@const value = guess?.[column] ?? ''}
@@ -375,11 +375,11 @@
 	}
 
 	.keyboard button[data-key='enter'] {
-		right: calc(50% + 3.5 * var(--size) + 0.8rem);
+		right: calc(50% + 3.5 * var (--size) + 0.8rem);
 	}
 
 	.keyboard button[data-key='backspace'] {
-		left: calc(50% + 3.5 * var(--size) + 0.8rem);
+		left: calc(50% + 3.5 * var (--size) + 0.8rem);
 	}
 
 	.keyboard button[data-key='enter']:disabled {


### PR DESCRIPTION
Update the `div.row` loop to use the correct number of squares required to type the word.

* Update the `div.row` loop to use `Array.from(Array(data.answerLength).keys())` instead of `Array.from(Array(10).keys())`
* Fix minor typo in CSS variable usage for `right` and `left` properties of `.keyboard button[data-key='enter']` and `.keyboard button[data-key='backspace']`

